### PR TITLE
Удалит ненужную обертку для компонента Logo

### DIFF
--- a/src/common/Logo/Logo.styles.ts
+++ b/src/common/Logo/Logo.styles.ts
@@ -1,7 +1,13 @@
 import styled from 'styled-components';
+import logo from './assets/logo.png';
 import LogoSize from './consts';
 
-const Img = styled.img`
+const Img = styled.img.attrs({
+  src: logo,
+  width: LogoSize.WIDTH,
+  height: LogoSize.HEIGHT,
+  alt: 'Logo',
+})`
   display: block;
   width: ${LogoSize.WIDTH}px;
   height: ${LogoSize.HEIGHT}px;

--- a/src/common/Logo/index.tsx
+++ b/src/common/Logo/index.tsx
@@ -1,8 +1,3 @@
-import React from 'react';
 import Img from './Logo.styles';
-import logo from './assets/logo.png';
-import LogoSize from './consts';
 
-export default function Logo(): JSX.Element {
-  return <Img src={logo} width={LogoSize.WIDTH} height={LogoSize.HEIGHT} alt="Logo" />;
-}
+export default Img;


### PR DESCRIPTION
Нет необходимости в дополнительном уровне компонента,
для того чтобы пробросить нативные пропсы-аттрибуты,
которые затем стилизованный компонент пробросит нативному HTML-элементу