### PR TITLE
Добавит константу visuallyHidden для a11y

### DIFF
--- a/src/constants/a11y.ts
+++ b/src/constants/a11y.ts
@@ -1,0 +1,19 @@
+import { css } from 'styled-components';
+
+const visuallyHidden = css`
+  position: absolute;
+
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  border: 0;
+  padding: 0;
+
+  white-space: nowrap;
+
+  clip-path: inset(100%);
+  clip: rect(0 0 0 0);
+  overflow: hidden;
+`;
+
+export default visuallyHidden;


### PR DESCRIPTION
Необходима для скрытия элементов со страницы без удаления из дерева доступности. Самый частый кейс это скрытие нативных чекбоксов и радиокнопок для кастомной стилизации.